### PR TITLE
Configurable get-words command, python3.4 compatibility, bring back async

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ Plug 'thalesmello/webcomplete.vim'
 completion engine for Neovim. `webcomplete` works with `deoplete` out of the box.
 Just start typing to see suggestions of words comming from your browser.
 
+## Options for deoplete
+
+- `g:deoplete#sources#webcomplete#script`: Execute this command-line string
+  to get a list of words instead of default internal `sh/webcomplete`. You may
+  add arguments to the string, e.g. `cat /tmp/words.txt`.
+
 ## Using with `completefunc` or `omnifunc`
 
 Vim allows you to define a `completefunc` or an `omnifunc` to give you

--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ Just start typing to see suggestions of words comming from your browser.
   to get a list of words instead of default internal `sh/webcomplete`. You may
   add arguments to the string, e.g. `cat /tmp/words.txt`.
 
+## Using with ncm2
+
+- `g:ncm2_webcomplete_script`: Same as option for deoplete, but for ncm2.
+
 ## Using with `completefunc` or `omnifunc`
 
 Vim allows you to define a `completefunc` or an `omnifunc` to give you

--- a/autoload/ncm2_webcomplete.vim
+++ b/autoload/ncm2_webcomplete.vim
@@ -1,0 +1,37 @@
+if get(s:, 'loaded', 0)
+    finish
+endif
+let s:loaded = 1
+
+let g:ncm2_webcomplete_enabled = get(g:, 'ncm2_webcomplete_enabled',  1)
+
+let g:ncm2_webcomplete#proc = yarp#py3('ncm2_webcomplete')
+
+let g:ncm2_webcomplete#source = get(g:, 'ncm2_webcomplete#look_source', {
+            \ 'name': 'web',
+            \ 'priority': 6,
+            \ 'mark': 'web',
+            \ 'on_complete': 'ncm2_webcomplete#on_complete',
+            \ 'on_warmup': 'ncm2_webcomplete#on_warmup'
+            \ })
+
+let g:ncm2_webcomplete#source = extend(g:ncm2_webcomplete#source,
+            \ get(g:, 'ncm2_webcomplete#source_override', {}),
+            \ 'force')
+
+function! ncm2_webcomplete#init()
+    call ncm2#register_source(g:ncm2_webcomplete#source)
+endfunction
+
+function! ncm2_webcomplete#on_warmup(ctx)
+    call g:ncm2_webcomplete#proc.jobstart()
+endfunction
+
+function! ncm2_webcomplete#on_complete(ctx)
+    let s:is_enabled = get(b:, 'ncm2_webcomplete_enabled',
+                \ get(g:, 'ncm2_webcomplete_enabled', 1))
+    if ! s:is_enabled
+        return
+    endif
+    call g:ncm2_webcomplete#proc.try_notify('on_complete', a:ctx)
+endfunction

--- a/autoload/ncm2_webcomplete.vim
+++ b/autoload/ncm2_webcomplete.vim
@@ -5,6 +5,9 @@ let s:loaded = 1
 
 let g:ncm2_webcomplete_enabled = get(g:, 'ncm2_webcomplete_enabled',  1)
 
+let g:ncm2_webcomplete_script = get(g:, 'ncm2_webcomplete_script',
+            \ expand('<sfile>:h:h') . "/sh/webcomplete")
+
 let g:ncm2_webcomplete#proc = yarp#py3('ncm2_webcomplete')
 
 let g:ncm2_webcomplete#source = get(g:, 'ncm2_webcomplete#source', {

--- a/autoload/ncm2_webcomplete.vim
+++ b/autoload/ncm2_webcomplete.vim
@@ -7,7 +7,7 @@ let g:ncm2_webcomplete_enabled = get(g:, 'ncm2_webcomplete_enabled',  1)
 
 let g:ncm2_webcomplete#proc = yarp#py3('ncm2_webcomplete')
 
-let g:ncm2_webcomplete#source = get(g:, 'ncm2_webcomplete#look_source', {
+let g:ncm2_webcomplete#source = get(g:, 'ncm2_webcomplete#source', {
             \ 'name': 'web',
             \ 'priority': 6,
             \ 'mark': 'web',

--- a/ncm2-plugin/ncm2_webcomplete.vim
+++ b/ncm2-plugin/ncm2_webcomplete.vim
@@ -1,0 +1,1 @@
+call ncm2_webcomplete#init()

--- a/pythonx/ncm2_webcomplete.py
+++ b/pythonx/ncm2_webcomplete.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+
+import vim
+from ncm2 import Ncm2Source, getLogger
+import re
+from os.path import expanduser, expandvars
+import subprocess
+
+from os.path import dirname, abspath, join, pardir, expandvars, expanduser
+from subprocess import check_output, PIPE
+from threading import Thread, Event
+
+logger = getLogger(__name__)
+
+
+def log(msg):
+    from datetime import datetime
+    timestamp = datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S,%f")
+    with open('/tmp/ncm2-webcomplete.log', 'a') as file_:
+        file_.write('%s %s\n' % (timestamp, msg))
+
+
+class Source(Ncm2Source):
+    def __init__(self, nvim):
+        super(Source, self).__init__(nvim)
+        # self.executable_look = nvim.call('executable', 'look')
+        # filedir = dirname(abspath(__file__))
+        # projectdir = abspath(join(filedir, pardir))
+        # join(projectdir, 'sh', 'webcomplete')
+        self.__script = expanduser(expandvars('~/.local/bin/bt words'))
+        # log('script: %s' % self.__script)
+
+    def on_complete(self, ctx):
+
+        # query = ctx['base']
+        #
+        # if not self.executable_look:
+        #     return
+
+        try:
+            # log('ctx: %s' % ctx)
+            matches = self._get_matches()
+            # log('matches: %s' % matches)
+            self.complete(ctx, ctx['startccol'], matches)
+        except subprocess.CalledProcessError as e:
+            log('error: %s' % e)
+            return
+
+    def _get_matches(self):
+        output = check_output(self.__script, shell=True)
+        candidates = output.decode('utf-8', errors='ignore').splitlines()
+        return [{'word': word} for word in candidates]
+
+
+source = Source(vim)
+
+on_complete = source.on_complete

--- a/pythonx/ncm2_webcomplete.py
+++ b/pythonx/ncm2_webcomplete.py
@@ -26,9 +26,7 @@ class Source(Ncm2Source):
 
         filedir = dirname(abspath(__file__))
         projectdir = abspath(join(filedir, pardir))
-        self.__script = join(projectdir, 'sh', 'webcomplete')
-        self.__script = self.nvim.eval('g:ncm2_webcomplete_script') \
-            or self.__script
+        self.__script = self.nvim.eval('g:ncm2_webcomplete_script')
         self.__script = expanduser(expandvars(self.__script))
 
     def on_complete(self, ctx):

--- a/pythonx/ncm2_webcomplete.py
+++ b/pythonx/ncm2_webcomplete.py
@@ -1,14 +1,14 @@
 # -*- coding: utf-8 -*-
 
-import vim
-from ncm2 import Ncm2Source, getLogger
 import re
-from os.path import expanduser, expandvars
 import subprocess
-
 from os.path import dirname, abspath, join, pardir, expandvars, expanduser
 from subprocess import check_output, PIPE
 from threading import Thread, Event
+
+import vim
+from ncm2 import Ncm2Source, getLogger
+
 
 logger = getLogger(__name__)
 
@@ -23,24 +23,18 @@ def log(msg):
 class Source(Ncm2Source):
     def __init__(self, nvim):
         super(Source, self).__init__(nvim)
-        # self.executable_look = nvim.call('executable', 'look')
-        # filedir = dirname(abspath(__file__))
-        # projectdir = abspath(join(filedir, pardir))
-        # join(projectdir, 'sh', 'webcomplete')
-        self.__script = expanduser(expandvars('~/.local/bin/bt words'))
-        # log('script: %s' % self.__script)
+
+        filedir = dirname(abspath(__file__))
+        projectdir = abspath(join(filedir, pardir))
+        self.__script = join(projectdir, 'sh', 'webcomplete')
+        self.__script = self.nvim.eval('g:ncm2_webcomplete_script') \
+            or self.__script
+        self.__script = expanduser(expandvars(self.__script))
 
     def on_complete(self, ctx):
 
-        # query = ctx['base']
-        #
-        # if not self.executable_look:
-        #     return
-
         try:
-            # log('ctx: %s' % ctx)
             matches = self._get_matches()
-            # log('matches: %s' % matches)
             self.complete(ctx, ctx['startccol'], matches)
         except subprocess.CalledProcessError as e:
             log('error: %s' % e)
@@ -55,3 +49,4 @@ class Source(Ncm2Source):
 source = Source(vim)
 
 on_complete = source.on_complete
+

--- a/rplugin/python3/deoplete/sources/webcomplete.py
+++ b/rplugin/python3/deoplete/sources/webcomplete.py
@@ -10,13 +10,6 @@ from .base import Base
 import deoplete.util
 
 
-def log(msg):
-    from datetime import datetime
-    timestamp = datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S,%f")
-    with open('/tmp/deoplete-webcomplete.log', 'a') as file_:
-        file_.write('%s %s\n' % (timestamp, msg))
-
-
 class Source(Base):
     def __init__(self, vim):
         super().__init__(vim)
@@ -50,7 +43,6 @@ class Source(Base):
 
     def gather_candidates(self, context):
         if not self._is_same_context(context['input']):
-            log('Reset cache: %s' % context['input'])
             self.__last_input = context['input']
             # The input has changed, notify background thread to fetch new words
             self.__refresh.set()

--- a/rplugin/python3/deoplete/sources/webcomplete.py
+++ b/rplugin/python3/deoplete/sources/webcomplete.py
@@ -4,8 +4,7 @@ complete words from your Chrome instance in your editor.'''
 
 from os.path import dirname, abspath, join, pardir
 from subprocess import check_output, PIPE
-from threading import Thread
-from queue import Queue, Empty
+from threading import Thread, Event
 
 from .base import Base
 import deoplete.util
@@ -31,30 +30,24 @@ class Source(Base):
         filedir = dirname(abspath(__file__))
         projectdir = abspath(join(filedir, pardir, pardir, pardir, pardir))
         self.__script = join(projectdir, 'sh', 'webcomplete')
-        self._tasks = Queue()
-        self._thread = Thread(target=self.background_thread, daemon=True)
-        self._thread.start()
+        self.__refresh = Event()
+        self.__thread = Thread(target=self.background_thread, daemon=True)
+        self.__thread.start()
 
     def background_thread(self):
         while True:
-            input_ = self._tasks.get()
+            self.__refresh.wait()
+            self.__refresh.clear()
             output = check_output(self.__script.split(), shell=True)
             candidates = output.decode('utf-8').splitlines()
             self.__cache = [{'word': word} for word in candidates]
-
-            # Clear the queue
-            while not self._tasks.empty():
-                try:
-                    self._tasks.get(block=False)
-                except Empty:
-                    break
 
     def gather_candidates(self, context):
         if not self._is_same_context(context['input']):
             log('Reset cache: %s' % context['input'])
             self.__last_input = context['input']
             # The input has changed, notify background thread to fetch new words
-            self._tasks.put(self.__last_input)
+            self.__refresh.set()
 
         if self.__cache is not None:
             # Return what we have now, though results may be a bit outdated

--- a/rplugin/python3/deoplete/sources/webcomplete.py
+++ b/rplugin/python3/deoplete/sources/webcomplete.py
@@ -8,6 +8,13 @@ from .base import Base
 import deoplete.util
 
 
+def log(msg):
+    from datetime import datetime
+    timestamp = datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S,%f")
+    with open('/tmp/deoplete-webcomplete.log', 'a') as file_:
+        file_.write('%s %s\n' % (timestamp, msg))
+
+
 class Source(Base):
     def __init__(self, vim):
         super().__init__(vim)
@@ -23,9 +30,10 @@ class Source(Base):
         self.__script = join(projectdir, 'sh', 'webcomplete')
 
     def gather_candidates(self, context):
-        context['is_async'] = True
+        # context['is_async'] = True
 
         if not self._is_same_context(context['input']):
+            log('Reset cache: %s' % context['input'])
             self.__last_input = context['input']
             self.__cache = None
 

--- a/rplugin/python3/deoplete/sources/webcomplete.py
+++ b/rplugin/python3/deoplete/sources/webcomplete.py
@@ -2,7 +2,7 @@
 This plugin works with Neovim and Deoplete, allowing you to
 complete words from your Chrome instance in your editor.'''
 
-from os.path import dirname, abspath, join, pardir
+from os.path import dirname, abspath, join, pardir, expandvars, expanduser
 from subprocess import check_output, PIPE
 from threading import Thread, Event
 
@@ -34,11 +34,17 @@ class Source(Base):
         self.__thread = Thread(target=self.background_thread, daemon=True)
         self.__thread.start()
 
+    def on_init(self, context):
+        vars = context['vars']
+
+        self.__script = expandvars(expanduser(
+            vars.get('deoplete#sources#webcomplete#script', self.__script)))
+
     def background_thread(self):
         while True:
             self.__refresh.wait()
             self.__refresh.clear()
-            output = check_output(self.__script.split(), shell=True)
+            output = check_output(self.__script, shell=True)
             candidates = output.decode('utf-8').splitlines()
             self.__cache = [{'word': word} for word in candidates]
 

--- a/sh/webcomplete
+++ b/sh/webcomplete
@@ -1,17 +1,4 @@
 #!/bin/sh
 
 
-# cat << EOF
-# PySequenceMethods
-# PySequence_Check
-# PySequence_Concat
-# PySequence_Contains
-# PySequence_GetItem
-# PySequence_InPlaceConcat
-# PySequence_InPlaceRepeat
-# PySequence_Repeat
-# PySequence_SetItem
-# PySequence_Size
-# EOF
-bt words
-#osascript -l JavaScript "$(dirname "$0")/get-words" "google chrome"
+osascript -l JavaScript "$(dirname "$0")/get-words" "google chrome"

--- a/sh/webcomplete
+++ b/sh/webcomplete
@@ -1,3 +1,17 @@
 #!/bin/sh
 
-osascript -l JavaScript "$(dirname "$0")/get-words" "google chrome"
+
+cat << EOF
+PySequenceMethods
+PySequence_Check
+PySequence_Concat
+PySequence_Contains
+PySequence_GetItem
+PySequence_InPlaceConcat
+PySequence_InPlaceRepeat
+PySequence_Repeat
+PySequence_SetItem
+PySequence_Size
+EOF
+#bt words
+#osascript -l JavaScript "$(dirname "$0")/get-words" "google chrome"

--- a/sh/webcomplete
+++ b/sh/webcomplete
@@ -1,4 +1,3 @@
 #!/bin/sh
 
-
 osascript -l JavaScript "$(dirname "$0")/get-words" "google chrome"

--- a/sh/webcomplete
+++ b/sh/webcomplete
@@ -1,17 +1,17 @@
 #!/bin/sh
 
 
-cat << EOF
-PySequenceMethods
-PySequence_Check
-PySequence_Concat
-PySequence_Contains
-PySequence_GetItem
-PySequence_InPlaceConcat
-PySequence_InPlaceRepeat
-PySequence_Repeat
-PySequence_SetItem
-PySequence_Size
-EOF
-#bt words
+# cat << EOF
+# PySequenceMethods
+# PySequence_Check
+# PySequence_Concat
+# PySequence_Contains
+# PySequence_GetItem
+# PySequence_InPlaceConcat
+# PySequence_InPlaceRepeat
+# PySequence_Repeat
+# PySequence_SetItem
+# PySequence_Size
+# EOF
+bt words
 #osascript -l JavaScript "$(dirname "$0")/get-words" "google chrome"


### PR DESCRIPTION
Hello! I thought about breaking this into smaller pull requests, but the code is rather small, so I'm not sure it was worth it. This patch does the following:

1. Adds a deoplete option `g:deoplete#sources#webcomplete#script` to configure the command that prints a list of words (instead of default `sh/webcomplete`)

2. Replaces subprocess.run with subprocess.check_output because there is no `run` yet in Python3.4.

3. Brings back the async but in a rather different way. I have my own script that prints a list of words from the active pages of my browsers, but unfortunately it's not very snappy. It executes in about 1..2 sec, so it's a bit annoying in vim when I have to wait for the words to show up. Instead, I cache the results and immediately return the cache, and also send "retrieve the words again" signal to the background thread. Even though technically we potentially receive results from the previous query, in practice it's not a problem because 1. active page does not change that often 2. you are likely to trigger another "retrieve the words again" signal when you start a new word and `_is_same_context` returns False.