### PR TITLE
Add support for qutebrowser.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,11 @@
 A Vim plugin that completes words from the currently open web page in your
 browser.
 
-Currently only works on Mac OS and Chrome. There is a [fork that works with Firefox](https://github.com/kimat/webcomplete.vim).
+Currently works with:
+
+- Chrome on Mac OS.
+- [Qutebrowser](https://github.com/qutebrowser/qutebrowser) on Linux and MacOS.
+- Firefox [in a fork](https://github.com/kimat/webcomplete.vim).
 
 ![demo](./demo.gif)
 
@@ -62,6 +66,12 @@ Currently this plugin only supports Google Chrome on Mac OS.
 
 To use it, you must enable "Allow JavaScript from Apple Events" in View >
 Developer submenu.
+
+## Using with Qutebrowser
+
+Set one of the `_webcomplete_script` variables (described above) to
+`$plugin_dir/sh/qutebrowser/webcomplete`, where `$plugin_dir` is the location
+of this plugin.
 
 ## Using with Firefox
 

--- a/sh/qutebrowser/userscript
+++ b/sh/qutebrowser/userscript
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+
+# Dump all words on the viewed page to the output file (arg $1)
+grep -o -E '\w+' "$QUTE_TEXT" | sort | uniq > $1

--- a/sh/qutebrowser/webcomplete
+++ b/sh/qutebrowser/webcomplete
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# We use a FIFO because:
+# 1. We can start reading before qutebrowser finishes writing
+# 2. It minimizes the opportunity for another process to read the file
+tmpdir=$(mktemp -d)
+fifo="$tmpdir/fifo"
+mkfifo "$fifo"
+
+# We leverage qutebrowser's userscript feature to get the text of the page
+qutebrowser ":spawn -u $(dirname "$0")/userscript "$fifo"" >/dev/null 2>&1 &
+cat "$fifo"
+
+# unnecessary, but let's not litter /tmp
+rm -r "$tmpdir"


### PR DESCRIPTION
This adds support for
[qutebrowser](https://github.com/qutebrowser/qutebrowser), a
keyboard-centric browser.

I tested this on Linux, but it should work on Mac as well.

If there isn't a qutebrowser instance open, it will open one, which
probably isn't desirable, but I don't see a way to avoid this with
qutebrowser's existing cli flags.